### PR TITLE
refactor: 重构浏览器渲染和配置系统

### DIFF
--- a/NCEF/MainWindow.cs
+++ b/NCEF/MainWindow.cs
@@ -13,108 +13,118 @@ using System.Windows.Forms;
 
 namespace NCEF
 {
-
-public class MainWindow
-{
-  private ChromiumWebBrowser _browser;
-  private Texture2D _dxTexture;
-  private SpoutDX _spoutSender;
-  private SharpDX.Direct3D11.Device _dxDevice;
-  private int BROWSER_PORT = 9222;
-  private string SPOUT_ID = "";
-
-  public MainWindow()
-  {
-    string environmentVariable1 = Environment.GetEnvironmentVariable(nameof (BROWSER_PORT));
-    string environmentVariable2 = Environment.GetEnvironmentVariable(nameof (BROWSER_PORT));
-    if (!string.IsNullOrEmpty(environmentVariable2))
-      this.SPOUT_ID = environmentVariable2;
-    int result;
-    if (string.IsNullOrEmpty(environmentVariable1) || !int.TryParse(environmentVariable1, out result))
-      return;
-    this.BROWSER_PORT = result;
-  }
-
-  public async Task InitWebViewAsync()
-  {
-    CefSettings settings = new CefSettings();
-    // 设定 CEF 缓存和资源目录
-    string gameDir = Environment.CurrentDirectory;
-    settings.CachePath = Path.Combine(gameDir, "User Data"); // 浏览器缓存
-    settings.LogFile = Path.Combine(gameDir, "cef.log");
-
-    settings.WindowlessRenderingEnabled = true;
-    settings.EnableAudio();
-    settings.CefCommandLineArgs.Add("remote-debugging-port", this.BROWSER_PORT.ToString());
-    Cef.Initialize((CefSettingsBase) settings, true);
-    this._browser = new ChromiumWebBrowser("https://example.com/", (IBrowserSettings) new BrowserSettings()
+    public class MainWindow
     {
-      WindowlessFrameRate = 120
-    });
-    LoadUrlAsyncResponse urlAsyncResponse = await this._browser.WaitForInitialLoadAsync();
-    Rectangle bounds = Screen.PrimaryScreen.Bounds;
-    int screenWidth = bounds.Width;
-    bounds = Screen.PrimaryScreen.Bounds;
-    int screenHeight = bounds.Height;
-    this.InitDirectXAndSpout(screenWidth, screenHeight);
-    this._browser.Paint += new EventHandler<OnPaintEventArgs>(this.Browser_Paint);
-    this._browser.Size = new Size(screenWidth, screenHeight);
-    settings = (CefSettings) null;
-  }
+        private ChromiumWebBrowser _browser;
+        private Texture2D _dxTexture;
+        private SpoutDX _spoutSender;
+        private SharpDX.Direct3D11.Device _dxDevice;
+        private int BROWSER_PORT;
+        private string SPOUT_ID;
+        private int MAXFPS;
+        private string CUSTOMIZE_LOADING_SCREEN_URL = "";
+        public MainWindow()
+        {
+            this.SPOUT_ID = GetEnvString("SPOUT_ID", "NCEF");
+            this.BROWSER_PORT = GetEnvInt("BROWSER_PORT", 9222);
+            this.MAXFPS = GetEnvInt("MAXFPS", 120);
+            this.CUSTOMIZE_LOADING_SCREEN_URL = GetEnvString("CUSTOMIZE_LOADING_SCREEN_URL", "https://example.com/");
+        }
 
-  private void InitDirectXAndSpout(int width, int height)
-  {
-    this._dxDevice = new SharpDX.Direct3D11.Device(DriverType.Hardware, DeviceCreationFlags.BgraSupport);
-    this._dxTexture = new Texture2D(this._dxDevice, new Texture2DDescription()
-    {
-      Width = width,
-      Height = height,
-      MipLevels = 1,
-      ArraySize = 1,
-      Format = SharpDX.DXGI.Format.B8G8R8A8_UNorm,
-      SampleDescription = new SampleDescription(1, 0),
-      Usage = ResourceUsage.Dynamic,
-      BindFlags = BindFlags.ShaderResource,
-      CpuAccessFlags = CpuAccessFlags.Write,
-      OptionFlags = ResourceOptionFlags.None
-    });
-    this._spoutSender = new SpoutDX();
-    this._spoutSender.OpenDirectX(this._dxDevice.NativePointer);
-    this._spoutSender.SetSenderName("WebViewSpoutCapture_" + this.SPOUT_ID);
-  }
+        private static string GetEnvString(string name, string defaultValue = "")
+        {
+            string value = Environment.GetEnvironmentVariable(name);
+            return string.IsNullOrWhiteSpace(value) ? defaultValue : value;
+        }
 
-  private void Browser_Paint(object sender, OnPaintEventArgs e)
-  {
-    if (this._dxTexture == null || this._spoutSender == null || e.BufferHandle == IntPtr.Zero)
-      return;
-    int width = e.Width;
-    int height = e.Height;
-    DeviceContext immediateContext = this._dxDevice.ImmediateContext;
-    DataBox dataBox = immediateContext.MapSubresource((SharpDX.Direct3D11.Resource) this._dxTexture, 0, MapMode.WriteDiscard, SharpDX.Direct3D11.MapFlags.None);
-    try
-    {
-      int length = width * 4;
-      byte[] numArray = new byte[length];
-      for (int index = 0; index < height; ++index)
-      {
-        Marshal.Copy(e.BufferHandle + index * length, numArray, 0, length);
-        Marshal.Copy(numArray, 0, dataBox.DataPointer + index * dataBox.RowPitch, length);
-      }
+        private static int GetEnvInt(string name, int defaultValue = 0)
+        {
+            string value = Environment.GetEnvironmentVariable(name);
+            return int.TryParse(value, out int result) ? result : defaultValue;
+        }
+
+        public async Task InitWebViewAsync()
+        {
+            CefSettings settings = new CefSettings();
+            // 设定 CEF 缓存和资源目录
+            string gameDir = Environment.CurrentDirectory;
+            settings.CachePath = Path.Combine(gameDir, "User Data"); // 浏览器缓存
+            settings.LogFile = Path.Combine(gameDir, "cef.log");
+
+            settings.WindowlessRenderingEnabled = true;
+            settings.EnableAudio();
+            settings.CefCommandLineArgs.Add("remote-debugging-port", this.BROWSER_PORT.ToString());
+            Cef.Initialize((CefSettingsBase)settings, true);
+            this._browser = new ChromiumWebBrowser(CUSTOMIZE_LOADING_SCREEN_URL, (IBrowserSettings)new BrowserSettings()
+            {
+                WindowlessFrameRate = MAXFPS
+            });
+            LoadUrlAsyncResponse urlAsyncResponse = await this._browser.WaitForInitialLoadAsync();
+            Rectangle bounds = Screen.PrimaryScreen.Bounds;
+            int screenWidth = bounds.Width;
+            bounds = Screen.PrimaryScreen.Bounds;
+            int screenHeight = bounds.Height;
+            this.InitDirectXAndSpout(screenWidth, screenHeight);
+            this._browser.Paint += new EventHandler<OnPaintEventArgs>(this.Browser_Paint);
+            this._browser.Size = new Size(screenWidth, screenHeight);
+            settings = (CefSettings)null;
+        }
+
+        private void InitDirectXAndSpout(int width, int height)
+        {
+            this._dxDevice = new SharpDX.Direct3D11.Device(DriverType.Hardware, DeviceCreationFlags.BgraSupport);
+            this._dxTexture = new Texture2D(this._dxDevice, new Texture2DDescription()
+            {
+                Width = width,
+                Height = height,
+                MipLevels = 1,
+                ArraySize = 1,
+                Format = SharpDX.DXGI.Format.B8G8R8A8_UNorm,
+                SampleDescription = new SampleDescription(1, 0),
+                Usage = ResourceUsage.Dynamic,
+                BindFlags = BindFlags.ShaderResource,
+                CpuAccessFlags = CpuAccessFlags.Write,
+                OptionFlags = ResourceOptionFlags.None
+            });
+            this._spoutSender = new SpoutDX();
+            this._spoutSender.OpenDirectX(this._dxDevice.NativePointer);
+            this._spoutSender.SetSenderName("WebViewSpoutCapture_" + this.SPOUT_ID);
+        }
+
+        private void Browser_Paint(object sender, OnPaintEventArgs e)
+        {
+            if (this._dxTexture == null || this._spoutSender == null || e.BufferHandle == IntPtr.Zero)
+                return;
+            int width = e.Width;
+            int height = e.Height;
+            DeviceContext immediateContext = this._dxDevice.ImmediateContext;
+            DataBox dataBox = immediateContext.MapSubresource((SharpDX.Direct3D11.Resource)this._dxTexture, 0,
+                MapMode.WriteDiscard, SharpDX.Direct3D11.MapFlags.None);
+            try
+            {
+                int length = width * 4;
+                byte[] numArray = new byte[length];
+                for (int index = 0; index < height; ++index)
+                {
+                    Marshal.Copy(e.BufferHandle + index * length, numArray, 0, length);
+                    Marshal.Copy(numArray, 0, dataBox.DataPointer + index * dataBox.RowPitch, length);
+                }
+            }
+            finally
+            {
+                immediateContext.UnmapSubresource((SharpDX.Direct3D11.Resource)this._dxTexture, 0);
+            }
+
+            this._spoutSender.SendTexture(this._dxTexture.NativePointer);
+        }
+
+        public void OnClosed(EventArgs e)
+        {
+            this._browser?.Dispose();
+            this._dxTexture?.Dispose();
+            this._spoutSender?.Dispose();
+            this._dxDevice?.Dispose();
+            Cef.Shutdown();
+        }
     }
-    finally
-    {
-      immediateContext.UnmapSubresource((SharpDX.Direct3D11.Resource) this._dxTexture, 0);
-    }
-    this._spoutSender.SendTexture(this._dxTexture.NativePointer);
-  }
-
-  public void OnClosed(EventArgs e)
-  {
-    this._browser?.Dispose();
-    this._dxTexture?.Dispose();
-    this._spoutSender?.Dispose();
-    this._dxDevice?.Dispose();
-    Cef.Shutdown();
-  }
-}
 }


### PR DESCRIPTION
- 将Spout渲染逻辑从AbstractWebScreen提取到独立的BrowserRender类
- 添加配置系统支持自定义端口、Spout ID、最大FPS和加载页面URL
- 改进BrowserManager为单例模式并支持配置加载
- 优化NCEF主窗口环境变量处理
- 简化gradle配置并添加自动版本号递增功能
- 重构CheckNCEFExistsLoadingScreen的屏幕切换逻辑
- 更新BrowserProcess以支持新的配置选项